### PR TITLE
Make absinthe_plug an optional runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ end
 Worst case, you'll need to copy the code from the current `pipeline` target
 and add a call to `Opencensus.Absinthe.add_phases/1` as above.
 
+If you are using `DocumentResolver` modules, you will need to integrate into their
+`pipeline/1` callback as well. If your `DocumentResolver` modules do not yet
+override this callback, then this is fairly straightforward:
+
+```elixir
+def pipeline(%{pipeline: as_configured}) do
+  as_configured
+  |> Absinthe.Pipeline.from(__absinthe_plug_doc__(:remaining_pipeline))
+  |> Opencensus.Absinthe.add_schema_phases()
+end
+```
+
+If you already override the `pipeline/1` callback, just append this to the end:
+
+```elixir
+# ... result
+|> Opencensus.Absinthe.add_schema_phases()
+```
+
 ### Middleware
 
 Your [middleware callback][c:middleware/3] needs to run its output through

--- a/lib/opencensus/absinthe.ex
+++ b/lib/opencensus/absinthe.ex
@@ -74,7 +74,7 @@ defmodule Opencensus.Absinthe do
   ```elixir
   pipeline =
     Absinthe.Pipeline.for_document(schema, pipeline_opts)
-    |> Opencensus.Absinthe.add_phases()
+    |> Opencensus.Absinthe.add_schema_phases()
   ```
   """
   @spec add_phases(Absinthe.Pipeline.t()) :: Absinthe.Pipeline.t()

--- a/lib/opencensus/absinthe.ex
+++ b/lib/opencensus/absinthe.ex
@@ -69,6 +69,28 @@ defmodule Opencensus.Absinthe do
   end
 
   @doc """
+  Add tracing phases to an existing pipeline for schema.
+
+  ```elixir
+  pipeline =
+    Absinthe.Pipeline.for_document(schema, pipeline_opts)
+    |> Opencensus.Absinthe.add_phases()
+  ```
+  """
+  @spec add_phases(Absinthe.Pipeline.t()) :: Absinthe.Pipeline.t()
+  def add_schema_phases(pipeline) do
+    pipeline
+    |> Absinthe.Pipeline.insert_after(
+      Absinthe.Phase.Schema,
+      Opencensus.Absinthe.Phase.SchemaPush
+    )
+    |> Absinthe.Pipeline.insert_after(
+      Absinthe.Phase.Document.Result,
+      Opencensus.Absinthe.Phase.Pop
+    )
+  end
+
+  @doc """
   Add tracing middleware for field resolution.
 
   Specifically, prepends `Opencensus.Absinthe.Middleware` to the `middleware` chain if the field

--- a/lib/opencensus/absinthe.ex
+++ b/lib/opencensus/absinthe.ex
@@ -41,6 +41,25 @@ defmodule Opencensus.Absinthe do
 
   Worst case, you'll need to copy the code from the current `pipeline` target and add a call to
   `Opencensus.Absinthe.add_phases/1` as above.
+
+  If you are using `DocumentResolver` modules, you will need to integrate into their
+  `pipeline/1` callback as well. If your `DocumentResolver` modules do not yet
+  override this callback, then this is fairly straightforward:
+
+  ```elixir
+  def pipeline(%{pipeline: as_configured}) do
+    as_configured
+    |> Absinthe.Pipeline.from(__absinthe_plug_doc__(:remaining_pipeline))
+    |> Opencensus.Absinthe.add_schema_phases()
+  end
+  ```
+
+  If you already override the `pipeline/1` callback, just append this to the end:
+
+  ```elixir
+  # ... result
+  |> Opencensus.Absinthe.add_schema_phases()
+  ```
   """
 
   alias Absinthe.Middleware
@@ -77,7 +96,7 @@ defmodule Opencensus.Absinthe do
     |> Opencensus.Absinthe.add_schema_phases()
   ```
   """
-  @spec add_phases(Absinthe.Pipeline.t()) :: Absinthe.Pipeline.t()
+  @spec add_schema_phases(Absinthe.Pipeline.t()) :: Absinthe.Pipeline.t()
   def add_schema_phases(pipeline) do
     pipeline
     |> Absinthe.Pipeline.insert_after(

--- a/lib/opencensus/absinthe/middleware.ex
+++ b/lib/opencensus/absinthe/middleware.ex
@@ -12,15 +12,20 @@ defmodule Opencensus.Absinthe.Middleware do
   @impl true
   @spec call(Resolution.t(), term()) :: Resolution.t()
   def call(%Resolution{state: :unresolved} = resolution, field: field) do
-    acc = Acc.get(resolution)
+    case Acc.get(resolution) do
+      # nil ->
+      #   Logger.error("Handling an untraceable field: #{inspect(field, pretty: true)}")
+      #   resolution
 
-    span_options = %{
-      attributes: field |> extract_metadata() |> Enum.into(%{}, &stringify_keys/1)
-    }
+      acc ->
+        span_options = %{
+          attributes: field |> extract_metadata() |> Enum.into(%{}, &stringify_keys/1)
+        }
 
-    span_ctx = :oc_trace.start_span(field |> repr(), acc.span_ctx, span_options)
-    middleware = resolution.middleware ++ [{{__MODULE__, :on_complete}, span_ctx: span_ctx}]
-    %{resolution | middleware: middleware}
+        span_ctx = :oc_trace.start_span(field |> repr(), acc.span_ctx, span_options)
+        middleware = resolution.middleware ++ [{{__MODULE__, :on_complete}, span_ctx: span_ctx}]
+        %{resolution | middleware: middleware}
+    end
   end
 
   @doc false

--- a/lib/opencensus/absinthe/phase/push.ex
+++ b/lib/opencensus/absinthe/phase/push.ex
@@ -9,8 +9,9 @@ defmodule Opencensus.Absinthe.Phase.Push do
 
   @impl true
   @spec run(Blueprint.t(), keyword()) :: Phase.result_t()
-  def run(blueprint, _opts \\ []) do
-    parent_span_ctx = :ocp.with_child_span("Blueprint")
+  def run(blueprint, opts \\ []) do
+    child_span = Keyword.get(opts, :child_span, "Blueprint")
+    parent_span_ctx = :ocp.with_child_span(child_span)
     span_ctx = :ocp.current_span_ctx()
 
     acc = %Acc{

--- a/lib/opencensus/absinthe/phase/schema_push.ex
+++ b/lib/opencensus/absinthe/phase/schema_push.ex
@@ -1,0 +1,12 @@
+defmodule Opencensus.Absinthe.Phase.SchemaPush do
+  @moduledoc false
+
+  use Absinthe.Phase
+
+  @impl true
+  @spec run(Blueprint.t(), keyword()) :: Phase.result_t()
+  def run(blueprint, opts \\ []) do
+    opts = Keyword.put_new(opts, :child_span, "Blueprint")
+    Opencensus.Absinthe.Phase.Push.run(blueprint, opts)
+  end
+end

--- a/lib/opencensus/absinthe/phase/schema_push.ex
+++ b/lib/opencensus/absinthe/phase/schema_push.ex
@@ -3,6 +3,9 @@ defmodule Opencensus.Absinthe.Phase.SchemaPush do
 
   use Absinthe.Phase
 
+  alias Absinthe.Blueprint
+  alias Absinthe.Phase
+
   @impl true
   @spec run(Blueprint.t(), keyword()) :: Phase.result_t()
   def run(blueprint, opts \\ []) do

--- a/lib/opencensus/absinthe/plug.ex
+++ b/lib/opencensus/absinthe/plug.ex
@@ -28,8 +28,8 @@ defmodule Opencensus.Absinthe.Plug do
     """
     def traced_pipeline(config, pipeline_opts \\ []) do
       config
-      |> Absinthe.Plug.default_pipeline(pipeline_opts)
       |> Opencensus.Absinthe.add_phases()
+      |> Absinthe.Plug.default_pipeline(pipeline_opts)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Opencensus.Absinthe.MixProject do
 
   defp deps() do
     [
-      {:absinthe_plug, "~> 1.4.0", only: :dev, runtime: false},
+      {:absinthe_plug, "~> 1.4.0", optional: true},
       {:absinthe, "~> 1.4.0"},
       {:credo, "~> 0.10.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},


### PR DESCRIPTION
Per:
https://github.com/opencensus-beam/opencensus_absinthe/pull/13/files#r290670529

This resolves a race condition at compile-time. See upstream PR here:
https://github.com/opencensus-beam/opencensus_absinthe/pull/13